### PR TITLE
Make OKit build on FreeBSD and OpenBSD

### DIFF
--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -1,80 +1,163 @@
-#!/bin/bash
+#!/bin/sh
 
-[ ! -e "INSTALL.sh" ] && echo "Orion | OKit : Please run inside the directory this script is located in." && exit
+# -q for quiet means no ASCII art
+# Both -s or -q could've worked for this flag so I picked -q
+while
+	getopts q option
+do
+	case $option in
+	q) qflag=1;;
+	# When an unrecognised flag is seen, just exit.  We could do a real error/usage message before exit, but I didn't.
+	*) exit 1;;
+	esac
+done
 
-[ "$EUID" -ne 0 ] && echo "Orion | OKit : Please run as root." && exit
+if
+	[ ! -e "INSTALL.sh" ]
+then
+	echo "Orion | OKit : Please run inside the directory this script is located in."
+	exit 1
+fi
 
-clear
-# Thanks Ron Fritz!
-echo ""
-echo "o          \`O        o                                                     .oOOOo.  \`o    O          "
-echo "O           o       O                                                     .O     o.  o   O   o       "
-echo "o           O       o                                     O               O       o  O  O         O  "
-echo "O           O       O                                    oOo              o       O  oOo         oOo "
-echo "o     o     o .oOo. o  .oOo  .oOo. \`oOOoOO. .oOo.         o   .oOo.       O       o  o  o    O    o  "
-echo "O     O     O OooO' O  O     O   o  O  o  o OooO'         O   O   o       o       O  O   O   o    O  "
-echo "\`o   O o   O' O     o  o     o   O  o  O  O O             o   o   O       \`o     O'  o    o  O    o  "
-echo "\`OoO' \`OoO'  \`OoO' Oo \`OoO' \`OoO'  O  o  o \`OoO'         \`oO \`OoO'        \`OoooO'   O     O o'   \`oO"
-echo ""
+if
+	[ "$(id -u)" -ne 0 ]
+then
+	echo "Orion | OKit : Please run as root."
+	exit 1
+fi
+
+if [ -z "$qflag" ]
+then
+	tput clear
+	# Thanks Ron Fritz!
+	echo
+	echo "o          \`O        o                                                     .oOOOo.  \`o    O          "
+	echo "O           o       O                                                     .O     o.  o   O   o       "
+	echo "o           O       o                                     O               O       o  O  O         O  "
+	echo "O           O       O                                    oOo              o       O  oOo         oOo "
+	echo "o     o     o .oOo. o  .oOo  .oOo. \`oOOoOO. .oOo.         o   .oOo.       O       o  o  o    O    o  "
+	echo "O     O     O OooO' O  O     O   o  O  o  o OooO'         O   O   o       o       O  O   O   o    O  "
+	echo "\`o   O o   O' O     o  o     o   O  o  O  O O             o   o   O       \`o     O'  o    o  O    o  "
+	echo "\`OoO' \`OoO'  \`OoO' Oo \`OoO' \`OoO'  O  o  o \`OoO'         \`oO \`OoO'        \`OoooO'   O     O o'   \`oO"
+	echo
+fi
                                                                                                      
 
-[ ! -d "/usr/include/Orion" ] && mkdir "/usr/include/Orion"
+[ -d "/usr/include/Orion" ] || mkdir "/usr/include/Orion"
 
-if [ -e "/usr/lib/libOKit.so" ]; then
-	read -p "Orion | OKit is already installed, would you like to re-install? (Y\N) : " conf
+if [ -e "/usr/lib/libOKit.so" ]
+then
+	printf "Orion | OKit is already installed, would you like to re-install? (y/N) : "
+	read conf
 	case ${conf} in
-		n) echo "Orion | OKit : Aborted."; exit;;
-		N) echo "Orion | OKit : Aborted."; exit;;
+		[!Yy]) echo "Orion | OKit : Aborted."
+			exit 1;;
 	esac
+	# There's no error checking here in the next three rm commands...?  Just checking to see if it's intentional or not.  I don't think error-checking would be 100% necessary as you'll install over these files anyway.  Still would be nice, though.
 	rm -rf "/usr/include/Orion/_OKit"
 	rm "/usr/include/Orion/OKit"
 	rm "/usr/lib/libOKit.so"
 	echo "Orion | OKit : Reinstalling OKit."
 fi
 
-if ! dpkg -s "make" &>/dev/null; then 
-	read -p "Orion | OKit : \"make\" is not installed. It is required for OKit to be compiled. Would you like to install this dependency? (Y\N) : " conf
-	case ${conf} in
-		n) echo "Orion | OKit : Aborted."; exit;;
-		N) echo "Orion | OKit : Aborted."; exit;;
+# Instead of using dpkg for this test, you should see if a test like
+# command -v make
+# works or not.
+if ! dpkg -s "make" >/dev/null 2>&1
+then 
+	printf 'Orion | OKit : "make" is not installed. It is required for OKit to be compiled. Would you like to install this dependency? (y/N) : '
+	read confb
+	case ${confb} in
+		[!Yy]) echo 'Orion | OKit : Aborted.'
+			exit 1;;
 	esac
-	echo "Orion | OKit : Working on installing Make." & sudo apt-get install "make" -y && echo "Orion | OKit : Make successfully installed." || { echo "Orion | OKit : ERROR! Make could not be installed! Aborting."; exit; }
+	# sudo when already root?
+	echo "Orion | OKit : Working on installing Make."
+	if sudo apt-get install "make" -y
+	then
+		echo "Orion | OKit : Make successfully installed."
+	else
+		echo "Orion | OKit : ERROR! Make could not be installed! Aborting."
+		exit 1
+	fi
 fi
 
-if ! dpkg -s "libx11-dev" &>/dev/null; then 
-	read -p "Orion | OKit : \"libx11-dev\" is not installed. It is required for OKit to function. Would you like to install this dependency? (Y\N) : " conf
-	case ${conf} in
-		n) echo "Orion | OKit : Aborted."; exit;;
-		N) echo "Orion | OKit : Aborted."; exit;;
+if ! dpkg -s "libx11-dev" >/dev/null 2>&1
+then 
+	printf 'Orion | OKit : "libx11-dev" is not installed. It is required for OKit to function. Would you like to install this dependency? (y/N) : '
+	read confc
+	case ${confc} in
+		[!Yy]) echo 'Orion | OKit : Aborted.'
+			exit 1;;
 	esac
-	echo "Orion | OKit : Working on installing XLib." & sudo apt-get install "libx11-dev" -y && echo "Orion | OKit : XLib successfully installed." || { echo "Orion | OKit : ERROR! XLib could not be installed! Aborting."; exit; }
+	echo "Orion | OKit : Working on installing XLib."
+	if sudo apt-get install "libx11-dev" -y
+	then
+		echo "Orion | OKit : XLib successfully installed."
+	else
+		echo "Orion | OKit : ERROR! XLib could not be installed! Aborting."
+		exit 1
+	fi
 fi
 
-read -p "Orion | OKit : OKit is ready to be installed. Would you like to proceed? (Y\N) : " conf
-case ${conf} in
-	n) echo "Orion | OKit : Aborted."; exit;;
-	N) echo "Orion | OKit : Aborted."; exit;;
+printf 'Orion | OKit : OKit is ready to be installed. Would you like to proceed? (y/N) : '
+read confd
+case ${confd} in
+	[!Yy]) echo 'Orion | OKit : Aborted.'
+		exit 1;;
 esac
 
 echo "Orion | OKit : Working on installing OKit."
+if
+	cp -R "src/include/" "/usr/include/Orion/_OKit"
+then
+	echo 'Orion | OKit : ERROR! Failed to copy header files into "/usr/include/Orion/_OKit"! Aborting.'
+	exit 1
+fi
 
-cp -R "src/include/" "/usr/include/Orion/_OKit" || { echo "Orion | OKit : ERROR! Failed to copy header files into \"/usr/include/Orion/_OKit\"! Aborting."; exit; }
-cp "src/SYSHEADER" "/usr/include/Orion/OKit" && echo "Orion | OKit : Copied header files. Use \"#include <Orion/OKit>\" in your C++ files to use these headers. " || { echo "Orion | OKit : ERROR! Failed to copy redirect header as \"/usr/include/Orion/OKit\"! Aborting."; exit; }
+if
+	cp "src/SYSHEADER" "/usr/include/Orion/OKit"
+then
+	echo 'Orion | OKit : Copied header files. Use "#include <Orion/OKit>" in your C++ files to use these headers.'
+else
+	echo 'Orion | OKit : ERROR! Failed to copy redirect header as "/usr/include/Orion/OKit"! Aborting.'
+	exit 1
+fi
 
 echo "Orion | OKit : Compiling source code..."
-make shared >>/dev/null && echo "Orion | OKit : Successfully compiled OKit source code." || { echo "Orion | OKit : ERROR! Failed to compile source code! Aborting."; exit; }
-cp "libOKit.so" "/usr/lib/libOKit.so" && echo "Orion | OKit : Copied OKit library to system libaries directory." || { echo "Orion | OKit : ERROR! Failed to copy compiled library as \"/usr/lib/libOKit.so\"! Aborting."; exit; }
-rm *.o *.so &>/dev/null
+if
+	make shared >>/dev/null
+then
+	echo "Orion | OKit : Successfully compiled OKit source code."
+else
+	echo "Orion | OKit : ERROR! Failed to compile source code! Aborting."
+	exit 1
+fi
 
-echo ""
-echo ".oOOOo.                                             oO"
-echo "o     o                                             OO"
-echo "O.                                                  oO"
-echo " \`OOoo.                                             Oo"
-echo "      \`O O   o  .oOo  .oOo  .oOo. .oOo  .oOo        oO"
-echo "       o o   O  O     O     OooO' \`Ooo. \`Ooo.         "
-echo "O.    .O O   o  o     o     O         O     O       Oo"
-echo " \`oooO'  \`OoO'o \`OoO' \`OoO' \`OoO' \`OoO' \`OoO'       oO"
-echo ""
-echo ""                                                      
-echo "Orion | OKit : OKit has been successfully installed. To compile your applications with OKit, simply use the library flag \"-lOKit\", and read the files in \"docs\" for more information."
+if
+	cp "libOKit.so" "/usr/lib/libOKit.so"
+then
+	echo "Orion | OKit : Copied OKit library to system libaries directory."
+else
+	echo 'Orion | OKit : ERROR! Failed to copy compiled library as "/usr/lib/libOKit.so"! Aborting.'
+	exit 1
+fi
+
+rm ./*.o ./*.so >/dev/null 2>&1
+
+if [ -z "$qflag" ]
+then
+	echo
+	echo ".oOOOo.                                             oO"
+	echo "o     o                                             OO"
+	echo "O.                                                  oO"
+	echo " \`OOoo.                                             Oo"
+	echo "      \`O O   o  .oOo  .oOo  .oOo. .oOo  .oOo        oO"
+	echo "       o o   O  O     O     OooO' \`Ooo. \`Ooo.         "
+	echo "O.    .O O   o  o     o     O         O     O       Oo"
+	echo " \`oooO'  \`OoO'o \`OoO' \`OoO' \`OoO' \`OoO' \`OoO'       oO"
+	echo
+fi
+
+echo
+echo 'Orion | OKit : OKit has been successfully installed. To compile your applications with OKit, simply use the library flag "-lOKit", and read the files in "docs" for more information.'

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,25 @@
-CC=g++
-BINS= *.o
+CC=c++
+SRCS=src/CContainable.cpp src/CContainer.cpp src/CContext.cpp src/CNodeArray.cpp src/CXEvent.cpp src/OCol.cpp src/OContainer.cpp src/OService.cpp src/OString.cpp src/OTheme.cpp src/OVec.cpp src/application.cpp src/xservice.cpp
+BINS=CContainable.o CContainer.o CContext.o CNodeArray.o CXEvent.o OCol.o OContainer.o OService.o OString.o OTheme.o OVec.o application.o xservice.o
+ALLBINS=$(BINS) testmain.o
 LIBS=-lX11
-FLAGS=-Wall -Wextra
+FLAGS=-Wall -Wextra -Wpedantic
 
 TESTMAIN=src/testmain.cc
 OUTNAME=OApp
 LIBNAME=libOKit.so
+
 all: output
 
 output: $(BINS)
 	$(CC) $(FLAGS) -c $(TESTMAIN) $(LIBS)
-	$(CC) $(FLAGS) $(BINS) -no-pie -o $(OUTNAME) $(LIBS)
+	$(CC) $(FLAGS) $(ALLBINS) -no-pie -o $(OUTNAME) $(LIBS)
 
 shared: $(BINS)
 	$(CC) -shared -fPIC $(FLAGS) $(BINS) -o $(LIBNAME) $(LIBS)
 
-%.o: src/%.cpp
-	$(CC) $(FLAGS) -fPIC -c $^ $(LIBS)
+$(BINS): $(SRCS)
+	$(CC) $(FLAGS) -fPIC -c $(SRCS) $(LIBS)
 run:
 	O_VERBOSE=1 ./$(OUTNAME)
 

--- a/UNINSTALL.sh
+++ b/UNINSTALL.sh
@@ -1,56 +1,133 @@
-#!/bin/bash
+#!/bin/sh
 
-[ ! -e "UNINSTALL.sh" ] && echo "Orion | OKit : Please run inside the directory this script is located in." && exit
+# -q for quiet means no ASCII art
+# Both -s or -q could've worked for this flag so I picked -q
+while
+	getopts q option
+do
+	case $option in
+	q) qflag=1;;
+	# When an unrecognised flag is seen, just exit.  We could do a real error/usage message before exit, but I didn't.
+	*) exit 1;;
+	esac
+done
 
-[ "$EUID" -ne 0 ] && echo "Orion | OKit : Please run as root." && exit
-
-[ ! -e "/usr/lib/libOKit.so" ] && echo "Orion | OKit : OKit is not installed. Aborting." && exit
-
-#Do eligibility checks here!
-
-clear
-# Thanks Ron Fritz!
-echo ""
-echo "O       o                                      o  o        .oOOOo.  \`o    O          "
-echo "o       O        o                            O  O        .O     o.  o   O   o       "
-echo "O       o                          O          o  o        O       o  O  O         O  "
-echo "o       o                         oOo         O  O        o       O  oOo         oOo "
-echo "o       O 'OoOo. O  'OoOo. .oOo    o   .oOoO' o  o        O       o  o  o    O    o  "
-echo "O       O  o   O o   o   O \`Ooo.   O   O   o  O  O        o       O  O   O   o    O  "
-echo "\`o     Oo  O   o O   O   o     O   o   o   O  o  o        \`o     O'  o    o  O    o  "
-echo " \`OoooO'O  o   O o'  o   O \`OoO'   \`oO \`OoO'o Oo Oo        \`OoooO'   O     O o'   \`oO"
-echo ""
-read -p "Orion | OKit : OKit is eligible to be uninstalled. Would you like to proceed? (Y/N) : " conf
-case ${conf} in
-	n) echo "Orion | OKit : Aborted."; exit;;
-	N) echo "Orion | OKit : Aborted."; exit;;
-esac
-
-rm "/usr/lib/libOKit.so" && echo "Orion | OKit : Uninstalled \"libOKit.so\"" || { echo "Orion | OKit : ERROR! Failed to uninstall \"libOKit.so\"! Aborting."; exit; }
-
-if [ -d "/usr/include/Orion/_OKit" ]; then
-	rm -rf "/usr/include/Orion/_OKit" && echo "Orion | OKit : Uninstalled OKit system headers." || { echo "Orion | OKit : ERROR! Failed to uninstall OKit system headers! Aborting."; exit; }
-	rm "/usr/include/Orion/OKit" && echo "Orion | OKit : Uninstalled OKit master header." || { echo "Orion | OKit : ERROR! Failed to uninstall OKit master header! Aborting."; exit; }
-	[ ! "$(ls -A /usr/include/Orion)" ] && rmdir "/usr/include/Orion/" && echo "Orion | OKit : Uninstalled Orion library directory. (Was empty.)"
+if
+	[ ! -e "UNINSTALL.sh" ]
+then
+	echo "Orion | OKit : Please run inside the directory this script is located in."
+	exit 1
 fi
 
-if dpkg -s "libx11-dev" &>/dev/null; then 
-	read -p "Orion | OKit : XLib was installed alongside OKit and is no longer needed. Would you like to uninstall Xlib as well? (Y/N) : " conf
-	case ${conf} in
-		y | Y | "")
-			echo "Orion | OKit : Working on uninstalling \"libx11-dev\"." & sudo apt-get purge "libx11-dev" -y && echo "Orion | OKit : \"libx11-dev\" successfully uninstalled." || { echo "Orion | OKit : ERROR! Failed to uninstall \"libx11-dev\"! Aborting."; exit; };;
+if
+	[ "$(id -u)" -ne 0 ]
+then
+	echo "Orion | OKit : Please run as root."
+	exit 1
+fi
+
+if
+	[ ! -e "/usr/lib/libOKit.so" ]
+then
+	echo "Orion | OKit : OKit is not installed. Aborting."
+	exit 1
+fi
+
+# Do eligibility checks here!
+
+if [ -z "$qflag" ]
+then
+	tput clear
+	# Thanks Ron Fritz!
+	echo
+	echo "O       o                                      o  o        .oOOOo.  \`o    O          "
+	echo "o       O        o                            O  O        .O     o.  o   O   o       "
+	echo "O       o                          O          o  o        O       o  O  O         O  "
+	echo "o       o                         oOo         O  O        o       O  oOo         oOo "
+	echo "o       O 'OoOo. O  'OoOo. .oOo    o   .oOoO' o  o        O       o  o  o    O    o  "
+	echo "O       O  o   O o   o   O \`Ooo.   O   O   o  O  O        o       O  O   O   o    O  "
+	echo "\`o     Oo  O   o O   O   o     O   o   o   O  o  o        \`o     O'  o    o  O    o  "
+	echo " \`OoooO'O  o   O o'  o   O \`OoO'   \`oO \`OoO'o Oo Oo        \`OoooO'   O     O o'   \`oO"
+	echo
+fi
+
+printf "Orion | OKit : OKit is eligible to be uninstalled. Would you like to proceed? (y/N) : "
+read conf
+case ${conf} in
+	[!Yy])
+		echo "Orion | OKit : Aborted."
+		exit 1;;
+esac
+
+if
+	rm "/usr/lib/libOKit.so"
+then
+	echo 'Orion | OKit : Uninstalled "libOKit.so"'
+else
+	echo 'Orion | OKit : ERROR! Failed to uninstall "libOKit.so"! Aborting.'
+	exit 1
+fi
+
+if [ -d "/usr/include/Orion/_OKit" ]
+then
+	if
+		rm -rf "/usr/include/Orion/_OKit"
+	then
+		echo "Orion | OKit : Uninstalled OKit system headers."
+	else
+		echo "Orion | OKit : ERROR! Failed to uninstall OKit system headers! Aborting."
+		exit 1
+	fi
+
+	if
+		rm "/usr/include/Orion/OKit"
+	then
+		echo "Orion | OKit : Uninstalled OKit master header."
+	else
+		echo "Orion | OKit : ERROR! Failed to uninstall OKit master header! Aborting."
+		exit 1
+	fi
+
+	if
+		[ ! "$(ls -A /usr/include/Orion)" ]
+	then
+		rmdir "/usr/include/Orion/" && echo "Orion | OKit : Uninstalled Orion library directory. (Was empty.)"
+	fi
+fi
+
+if dpkg -s "libx11-dev" > /dev/null 2>&1
+then 
+	printf "Orion | OKit : XLib was installed alongside OKit and is no longer needed. Would you like to uninstall Xlib as well? (y/N) : "
+	read confb
+	case ${confb} in
+		y | Y)
+			echo 'Orion | OKit : Working on uninstalling "libx11-dev".'
+			if
+				# sudo?  Aren't we already root by now?  Also, consider moving -y in front of the package argument rather than behind it.  On Unix (in shell scripts) option flags are traditionally placed as early as possible.
+				sudo apt-get purge "libx11-dev" -y
+			then
+				echo 'Orion | OKit : "libx11-dev" successfully uninstalled.'
+			else
+				echo 'Orion | OKit : ERROR! Failed to uninstall "libx11-dev"! Aborting.'
+				exit 1
+			fi
+			;;
 	esac
 fi
 
-echo ""
-echo ".oOOOo.                                             oO"
-echo "o     o                                             OO"
-echo "O.                                                  oO"
-echo " \`OOoo.                                             Oo"
-echo "      \`O O   o  .oOo  .oOo  .oOo. .oOo  .oOo        oO"
-echo "       o o   O  O     O     OooO' \`Ooo. \`Ooo.         "
-echo "O.    .O O   o  o     o     O         O     O       Oo"
-echo " \`oooO'  \`OoO'o \`OoO' \`OoO' \`OoO' \`OoO' \`OoO'       oO"
-echo ""
-echo ""
+if [ -z "$qflag" ]
+then
+	echo
+	echo ".oOOOo.                                             oO"
+	echo "o     o                                             OO"
+	echo "O.                                                  oO"
+	echo " \`OOoo.                                             Oo"
+	echo "      \`O O   o  .oOo  .oOo  .oOo. .oOo  .oOo        oO"
+	echo "       o o   O  O     O     OooO' \`Ooo. \`Ooo.         "
+	echo "O.    .O O   o  o     o     O         O     O       Oo"
+	echo " \`oooO'  \`OoO'o \`OoO' \`OoO' \`OoO' \`OoO' \`OoO'       oO"
+	echo
+fi
+
+echo
 echo "Orion | OKit: OKit has been successfully uninstalled."

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -47,16 +47,27 @@ namespace Orion{
 
 		bool isNativeOApp=false;
 		pid_t pid=0;
-		const char* cwd=0;
+		const char* cwd=NULL;
 		const char* binpath=0;
 		const char* bindir=0;
 		const char* datapath=0;
 
 		static void _initCWD(void){
-			const char* tmp=get_current_dir_name();
-			if(tmp){
+			/*
+			 * get_current_dir_name() is GNU-only, getcwd() is the portable equivalent.
+			 * On any failure (both before and after the change from get_current_dir_name to getcwd) it's up to another part of the program to determine what to do with a NULL cwd value.
+			 * OPATH_MAX is so tiny.  256?  1024 is another common minimum.  Of course, using pathconf() and _PC_PATH_MAX would be more general.
+			 */
+			char* result;
+			char tmp[OPATH_MAX];
+			cwd = (const char*) malloc(OPATH_MAX);
+
+			result = getcwd(tmp, OPATH_MAX);
+			if(result == NULL){
+				cwd=NULL;
+			} else {
 				cwd=tmp;
-			}else{cwd=0;}
+			}
 		}
 
 		static void _initBinPathAndDir(void){

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -47,7 +47,7 @@ namespace Orion{
 
 		bool isNativeOApp=false;
 		pid_t pid=0;
-		const char* cwd=NULL;
+		char* cwd=NULL;
 		const char* binpath=0;
 		const char* bindir=0;
 		const char* datapath=0;
@@ -59,14 +59,11 @@ namespace Orion{
 			 * OPATH_MAX is so tiny.  256?  1024 is another common minimum.  Of course, using pathconf() and _PC_PATH_MAX would be more general.
 			 */
 			char* result;
-			char tmp[OPATH_MAX];
-			cwd = (const char*) malloc(OPATH_MAX);
+			cwd = (char*) malloc(OPATH_MAX);
 
-			result = getcwd(tmp, OPATH_MAX);
+			result = getcwd(cwd, OPATH_MAX);
 			if(result == NULL){
 				cwd=NULL;
-			} else {
-				cwd=tmp;
 			}
 		}
 

--- a/src/include/OContainer.hpp
+++ b/src/include/OContainer.hpp
@@ -47,7 +47,7 @@ namespace Orion{
 			/* Constructs an OContainer as a child of the first argument. */
 			OContainer(CContainer& parent, int x, int y, unsigned int w, unsigned int h);
 
-			friend void X::OContainer_EVH(void*,CXEvent*);
+			friend void X::OContainer_EVH(void*,X::CXEvent*);
 			friend void X::OContainer_DRAW(CDrawable* container);
 			
 			/* Sets the background colour of the OContainer. */

--- a/src/include/application.hpp
+++ b/src/include/application.hpp
@@ -29,6 +29,7 @@
 #include <sys/types.h>
 
 /*Orion implementation for maximum amount of characters allowed in a directory path.*/
+/* OPATH_MAX is so tiny.  256?  1024 is another common minimum.  Of course, using pathconf() and _PC_PATH_MAX would be more general. */
 #define OPATH_MAX 256
 
 /* Wrapper if() statement for exiting upon fatal errors. Include <stdlib.h>! */

--- a/src/include/application.hpp
+++ b/src/include/application.hpp
@@ -86,7 +86,7 @@ namespace Orion{
 		/* The PID of your OApp. See OAPP_PID. */
 		extern pid_t pid;
 		/* Current Working Directory; where you launched the OApp. */
-		extern const char* cwd;
+		extern char* cwd;
 		/* Global system path to your OApp binary */
 		extern const char* binpath;
 		/* Global system directory which your OApp binary is located. */

--- a/src/testmain.cc
+++ b/src/testmain.cc
@@ -51,6 +51,7 @@ void myFunc(void* listener, X::CXEvent* event){
 // }
 
 int main(){
+	/* This ends up leading to a "~/.local/share/My OApp" directory being made, and having spaces in directories or filenames is not a good idea. */
 	OKitStart("My OApp");
 	
 	OCol col(255,86,15);


### PR DESCRIPTION
Hi!  I'm the FreeBSD /g/ poster who commented in your thread, and I made a GitHub account just for this! (I'll likely delete my account in a month)
These patches make OKit build on FreeBSD and OpenBSD.  They also add a -q flag to INSTALL.sh and UNINSTALL.sh that lets users use those scripts without ASCII art if they so request.  I also made most of the y/n questions default to No.
I'm a C and Unix programmer, and I DO NOT know C++, so please check the C++ diffs carefully.
I can set up Travis CI and Cirrus CI if you'd like, to have this repository automatically get built on GNU/Linux and FreeBSD, for free, if you'd like.
Please read the commit description for each of the seven commits.