### PR TITLE
Add CI to the OKit repository

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,9 @@
+freebsd_instance:
+  image_family: freebsd-12-1
+
+task:
+  install_script: pkg install -y libX11
+  script:
+  # The following line adds the proper include and library locations for libX11 on FreeBSD.  FreeBSD users manually need to do the same or similar when building OKit.
+    - printf '/FLAGS=/s/FLAGS=/FLAGS=-I\\/usr\\/local\\/include -L\\/usr\\/local\\/lib \nw\nq\n' | ed -s Makefile
+    - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+# arch is in beta, remove it if it doesn't work
+arch:
+ - amd64
+ - arm64
+
+language: cpp
+dist: focal
+
+script:
+ - make


### PR DESCRIPTION
This adds both Travis CI and Cirrus CI.  This lets the OKit repository be automatically built after every commit, and after every pull request submission (even before it's merged or rejected!)
The Travis CI builds on Ubuntu Focal Fossa, on AMD64 and ARM64, presumably using GCC.
The Cirrus CI builds on FreeBSD 12.1 using Clang, presumably on AMD64.
Not only does it give a whole success/fail for 'make', but you can look into each build to peruse for warnings.
Right now, success/fail is based only on the build succeeding or failing, as the produced binary is not run or tested.

edit:
This will require enabling Travis CI and Cirrus CI to use.  Both are available in the GitHub Marketplace, and both are free for open-source projects, meaning it'll be entirely free.  But enabling those is something you (the repo owner) have to do yourself.